### PR TITLE
Commenting out under-construction items

### DIFF
--- a/common/index.ejs
+++ b/common/index.ejs
@@ -24,7 +24,7 @@
                 class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
                 🔐 Single Sign-On
             </a>
-            <a href="/content-delivery-networks"
+            <!-- <a href="/content-delivery-networks"
                 class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
                 🚧 Content Delivery Networks
             </a>
@@ -43,7 +43,7 @@
             <a href="/recommendations"
                 class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
                 🚧 Personalization/Recommendations
-            </a>
+            </a> -->
         </div>
     </section>
 <h2 class="text-3xl font-bold mb-4 text-center mt-4">API Demos</h2>
@@ -52,7 +52,7 @@
            class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
             🍪 CHIPS
         </a>
-        <a href="/related-websites-sets"
+        <!-- <a href="/related-websites-sets"
            class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
             🚧 Related Website Sets
         </a>
@@ -63,7 +63,7 @@
         <a href="/fedcm"
            class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
             🚧 FedCM
-        </a>
+        </a> -->
     </div>
 </div>
 

--- a/common/index.ejs
+++ b/common/index.ejs
@@ -7,7 +7,7 @@
     <h1 class="text-3xl font-bold mb-8 text-center">Privacy Sandbox</h1>
     <section class="text-center mb-4">
         <h2 class="text-3xl font-bold mb-4 text-center">Scenarios</h2>
-        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
             <a href="/analytics"
                 class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
                 🔎 Analytics Tracking
@@ -24,26 +24,6 @@
                 class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
                 🔐 Single Sign-On
             </a>
-            <!-- <a href="/content-delivery-networks"
-                class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-                🚧 Content Delivery Networks
-            </a>
-            <a href="/create-account"
-                class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-                🚧 Creating an Account
-            </a>
-            <a href="/payment-flow"
-                class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-                🚧 Payment Flow
-            </a>
-            <a href="/third-party-auth"
-                class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-                🚧 Third-party Authentication
-            </a>
-            <a href="/recommendations"
-                class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-                🚧 Personalization/Recommendations
-            </a> -->
         </div>
     </section>
 <h2 class="text-3xl font-bold mb-4 text-center mt-4">API Demos</h2>
@@ -52,18 +32,6 @@
            class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
             🍪 CHIPS
         </a>
-        <!-- <a href="/related-websites-sets"
-           class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-            🚧 Related Website Sets
-        </a>
-        <a href="/privacy-state-tokens"
-           class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-            🚧 Privacy State Tokens
-        </a>
-        <a href="/fedcm"
-           class="block p-4 bg-white shadow rounded hover:bg-blue-500 hover:text-white transition duration-300">
-            🚧 FedCM
-        </a> -->
     </div>
 </div>
 


### PR DESCRIPTION
Based on the feedback from the latest call, the items under construction should be hidden for now.

This pull request will comment out the buttons and keep the routes to be used later:

**Before:**
<img width="1384" alt="Screenshot 2023-12-13 at 17 25 52" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/4dcb3a59-0489-4c2d-be08-8a527d314383">

**After**
<img width="1389" alt="Screenshot 2023-12-13 at 17 26 28" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/760a7069-82cb-49f8-b738-df495cc16d10">



