### PR TITLE
Adding dynamic colors to the safelist to be render by tailwind css CLI

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,5 +8,11 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  safelist: [
+    'bg-sky-50',
+    'bg-green-100',
+    'bg-blue-100',
+    'bg-red-100',
+  ],
 }
 


### PR DESCRIPTION
## Description

This pull request contains changes on the Tailwind CSS config file to include the dynamic colors set by the environment properties on the safelist. This change is to enforce the dynamic background color to be included in the build process to the main style file.

## Relevant Technical Choices

- `safelist` is a property that will always guarantee the class for background colors set on the `.env` file will be included by the Tailwind CLI

## Testing Instructions

1. Clone the repository and checkout `feature/add-safelist-to-render-domain-background` branch containing these changes.
2. Ensure you have Node.js and npm installed.
3. Run `npm install` to install all dependencies.
4. Set up the `.env` file to define background colors for different domains.
5. Start the server using `npm start` or `node app.js`.
6. Navigate to the homepage and check if the default background color changed to `bg-sky-50` or the `Domain A` changed to `bg-green-100`.
 