### PR TITLE
Removing duplicated footer from iframes

### DIFF
--- a/src/common/footer.ejs
+++ b/src/common/footer.ejs
@@ -1,5 +1,14 @@
-    <footer class="mt-auto text-center p-2 text-xs bg-white rounded-lg m-4 container-lg">
+
+    <footer class="main-footer mt-auto text-center p-2 text-xs bg-white rounded-lg m-4 container-lg">
         This project is part of the Privacy Sandbox Analysis Tool. To learn more, visit our <a href="https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki" class="text-blue-600 hover:underline" target="_blank" rel="noopener">Wiki Page</a>.
     </footer>
+    <script>
+        const mainFooter = document.querySelector('.main-footer');
+        const isIframe = window.self !== window.top;
+        
+        if (mainFooter && isIframe) {
+           mainFooter.remove(); 
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Description 

In the current solution, the footer gets duplicated when third-party content is loaded in an iframe, breaking the expected design. This pull request contains a script to hide the footer when the page is loaded from an iframe. 


## Relevant Technical Choices

The inline Javascript was a solution that could be reproduced locally, probably with multiple domains; it could be solved with Express JS checking `request.headers.referer`. 

## Testing Instructions

1. Clone the repository and checkout the `feature/removing-duplicated-footer-from-iframes` branch containing these changes.
2. Please make sure you have Node.js and `npm` installed.
3. Run `npm install` to install all dependencies.
4. Set up the `.env` file.
5. Start the server using `npm start`.
6. You can navigate to the demos "e-commerce" or "payment gateway"
7. Check if the footer is displayed only in the main content

## Screenshots

**e-commerce scenario before**

![e-commerce scenario before](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/e9c4df11-92f6-4489-aded-fa47b3f60f48)


**e-commerce scenario after**

![e-commerce scenario after](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/95e11aec-3efa-4763-95fe-057410d38f6b)
