### PR TITLE
Removing demo from all internal pages

### DIFF
--- a/src/demos/chips/index.ejs
+++ b/src/demos/chips/index.ejs
@@ -1,7 +1,7 @@
 <%- include(commonPath + '/header.ejs') %>
 
 <div class="container mx-auto py-8">
-	<h1 class="text-3xl font-bold mb-4 text-center">CHIPS Demos</h1>
+	<h1 class="text-3xl font-bold mb-4 text-center">CHIPS</h1>
 	<p class="text-center font-bold">Cookies Having Independent Partitioned State</p>
 	<div class="flex justify-center space-x-4 mt-4">
 		<a href="<%= protocol %>://<%= domainC %><% if (isPortPresent) { %>:<%= port %><% } %>/chips/analytics-first-party"

--- a/src/demos/chips/routes.js
+++ b/src/demos/chips/routes.js
@@ -6,7 +6,7 @@ const uuid = require( 'uuid' );
 router.get('/', (req, res) => {
 	// Send the default page
 	res.render(path.join(__dirname,'index'), {
-		title: 'CHIPS Demo'
+		title: 'CHIPS'
 	});
 });
 router.get('/analytics-first-party', (req, res) => {

--- a/src/demos/fedcm/routes.js
+++ b/src/demos/fedcm/routes.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
 	res.render('common/under-construction', {
-		title: '🚧 FedCM Demo'
+		title: '🚧 FedCM'
 	});
 });
 

--- a/src/demos/private-state-tokens/routes.js
+++ b/src/demos/private-state-tokens/routes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 router.get('/', (req, res) => {
 	res.sendFile(path.join(__dirname, 'index.html'));
 	res.render('common/under-construction', {
-		title: '🚧 Private State Tokens Demo'
+		title: '🚧 Private State Tokens'
 	});
 });
 

--- a/src/demos/related-websites-sets/routes.js
+++ b/src/demos/related-websites-sets/routes.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
 	res.render('common/under-construction', {
-		title: '🚧 Related Website  Sets Demo'
+		title: '🚧 Related Website  Sets'
 	});
 });
 

--- a/src/scenarios/analytics/index.ejs
+++ b/src/scenarios/analytics/index.ejs
@@ -1,7 +1,7 @@
 <%- include(commonPath + '/header.ejs') %>
 
 <div class="container mx-auto py-8">
-    <h1 class="text-3xl font-bold mb-4 text-center">Analytics Demo</h1>
+    <h1 class="text-3xl font-bold mb-4 text-center">Analytics</h1>
     <p class="text-lg font-bold mb-4 text-center">Here is a button that track clicks using third-party analytics service, check if it works.</p>
     <script src="<%= protocol %>://<%= domainC %><% if (isPortPresent) { %>:<%= port %><% } %>/analytics/analytics.js"></script>
     <div class="flex justify-center space-x-4 mt-4">

--- a/src/scenarios/analytics/routes.js
+++ b/src/scenarios/analytics/routes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 router.get('/', (req, res) => {
     // Send the default page
     res.render(path.join(__dirname,'index'), {
-        title: 'Analytics Demo'
+        title: 'Analytics'
     });
 });
 

--- a/src/scenarios/ecommerce/index.ejs
+++ b/src/scenarios/ecommerce/index.ejs
@@ -1,7 +1,7 @@
 <%- include(commonPath + '/header.ejs') %>
 
 <div class="container mx-auto py-8">
-	<h1 class="text-3xl font-bold mb-4 text-center">E-Commerce Demo</h1>
+	<h1 class="text-3xl font-bold mb-4 text-center">E-Commerce</h1>
 	<p class="text-lg font-bold mb-4 text-center">Here is an embedded Third-Party e-commerce site, check if you can add products to cart.</p>
 	<div class="mt-8 flex justify-center">
 		<iframe src="<%= protocol %>://<%= domainC %><% if (isPortPresent) { %>:<%= port %><% } %>/ecommerce/products" class="border border-8 rounded w-1/2 h-96"></iframe>

--- a/src/scenarios/ecommerce/routes.js
+++ b/src/scenarios/ecommerce/routes.js
@@ -6,7 +6,7 @@ const router = express.Router();
 // Middleware to setup common rendering variables
 router.use((req, res, next) => {
 	// Set common variables for rendering views
-	res.locals.title =  'E-Commerce Demo' // Set the page title
+	res.locals.title =  'E-Commerce - Privacy Sandbox' // Set the page title
 	next();  // Continue to the next middleware or route handler
 });
 

--- a/src/scenarios/embedded-video/index.ejs
+++ b/src/scenarios/embedded-video/index.ejs
@@ -1,7 +1,7 @@
 <%- include(commonPath + '/header.ejs') %>
 
 <div class="container mx-auto py-8">
-    <h1 class="text-3xl font-bold mb-4 text-center">Embedded Video Demo</h1>
+    <h1 class="text-3xl font-bold mb-4 text-center">Embedded Video</h1>
     <p class="text-lg font-bold mb-4 text-center">Here is an embedded Third-Party video player, check if you can play the video and if it shows up in your history in your logged in account.</p>
     <div class="mt-8 flex justify-center">
         <iframe class="border border-8 rounded" width="560" height="315" src="https://www.youtube.com/embed/aqz-KE-bpKQ?si=CuSLBTjNMf9NA1eg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/src/scenarios/embedded-video/routes.js
+++ b/src/scenarios/embedded-video/routes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
     res.render(path.join(__dirname,'index'), {
-        title: 'Embedded Video Demo'
+        title: 'Embedded Video'
     });
 });
 module.exports = router;

--- a/src/scenarios/payment-gateway/routes.js
+++ b/src/scenarios/payment-gateway/routes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.get( '/', ( req, res ) => {
 	res.render( path.join( __dirname, 'checkout' ), {
-		title: 'Payment Gateway Demo',
+		title: 'Payment Gateway',
 		item: "Virtual Badge for testing the site",
 		price: 10,
 	} );

--- a/src/scenarios/single-sign-on/routes.js
+++ b/src/scenarios/single-sign-on/routes.js
@@ -20,7 +20,7 @@ router.get('/profile', (req, res) => {
 	const domain = req.get('host');
 
 	if (email) {
-		res.render(path.join(__dirname, 'profile'), { title: 'Single Sign-On Demo for ' + domain, email: email });
+		res.render(path.join(__dirname, 'profile'), { title: 'Single Sign-On for ' + domain, email: email });
 	} else {
 		res.redirect('/single-sign-on/sign-in');
 	}
@@ -29,7 +29,7 @@ router.get('/profile', (req, res) => {
 router.get('/logout', (req, res) => {
 	const domain = req.get('host');
 	res.clearCookie('localemail');
-	res.render(path.join(__dirname, 'logout'), { title: 'Single Sign-On Demo for ' + domain });
+	res.render(path.join(__dirname, 'logout'), { title: 'Single Sign-On for ' + domain });
 });
 
 router.get('/login', (req, res) => {
@@ -45,7 +45,7 @@ router.get('/login', (req, res) => {
 
 router.get('/sign-in', (req, res) => {
 	const domain = req.get('host');
-	res.render(path.join(__dirname, 'signin'), { title: 'Single Sign-On Demo for ' + domain, protocol: 'https', domainC: res.locals.domainC });
+	res.render(path.join(__dirname, 'signin'), { title: 'Single Sign-On for ' + domain, protocol: 'https', domainC: res.locals.domainC });
 });
 
 router.post('/validate', (req, res) => {

--- a/src/scenarios/single-sign-on/signin.ejs
+++ b/src/scenarios/single-sign-on/signin.ejs
@@ -1,7 +1,7 @@
 <%- include(commonPath + '/header.ejs') %>
 
 <div class="container mx-auto py-8">
-	<h1 class="text-3xl font-bold mb-4 text-center">Single Sign-On Demo</h1>
+	<h1 class="text-3xl font-bold mb-4 text-center">Single Sign-On</h1>
 	<div class="text-center">
 		<button id="signInButton" class="bg-blue-500 text-white font-bold py-2 px-4 rounded-full inline-block">Sign In</button>
 	</div>


### PR DESCRIPTION
## Description 

The latest review was suggested to remove the word **demo** from all internal pages. This pull request contains changes to all internal pages removing the word **demo** from the page title and heading. 

## Screenshots
![Screenshot 2023-12-22 at 21 56 40](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/2a342e03-b8b5-403a-a86a-9b5d7cd366f5)

![Screenshot 2023-12-22 at 21 57 16](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/947f3680-32f2-4fa1-ab00-3adebebd0c99)

![Screenshot 2023-12-22 at 21 58 21](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/4d291780-9e92-44c9-af10-666092f07e68)

