### PR TITLE
Adding link to check YouTube history

### DIFF
--- a/src/scenarios/embedded-video/index.ejs
+++ b/src/scenarios/embedded-video/index.ejs
@@ -4,8 +4,13 @@
     <h1 class="text-3xl font-bold mb-4 text-center">Embedded Video Demo</h1>
     <p class="text-lg font-bold mb-4 text-center">Here is an embedded Third-Party video player, check if you can play the video and if it shows up in your history in your logged in account.</p>
     <div class="mt-8 flex justify-center">
-        <iframe class="border border-8 rounded" width="560" height="315" src="https://www.youtube.com/embed/aqz-KE-bpKQ?si=CuSLBTjNMf9NA1eg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="border-8 rounded" width="560" height="315" src="https://www.youtube.com/embed/aqz-KE-bpKQ?si=CuSLBTjNMf9NA1eg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
     </div>
+    <footer class="text-center m-4">
+        <a href="https://www.youtube.com/feed/history" target="_blank" rel="noopenner" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">
+            Check your YouTube history
+        </a>
+    </footer>
 </div>
 
 <%- include(commonPath + '/footer.ejs') %>


### PR DESCRIPTION
## Description 

This pull request includes a link to check the user's YouTube history in the embedded content scenario. The scenario uses a YouTube video to see the impact of third-party cookie deprecation and one of the effects is YouTube watching history not being capable of tracking videos outside YouTube. 

One of the steps in this audit is to open the YouTube history and add a link to the user history on the Embedded Scenario page, which will help users speed up the process. 

**Embebbed Content Page Before**
![embedded scenario before](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/447fa2f7-2b41-4f13-8d2d-3a3a840bbdfc)

**Embebbed Content Page After**
![embedded scenario after](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/db0f37a1-65b9-4ea3-869a-ab7bde72bd4f)
