### PR TITLE
Demo user preference

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,6 +66,7 @@ const scenarios = [
 	'analytics',
 	'embedded-video',
 	'payment-gateway',
+	'user-preferences',
 ];
 scenarios.forEach(scenario => {
 	const scenarioRoutes = require(`./src/scenarios/${scenario}/routes`);

--- a/public/assets/styles/style.css
+++ b/public/assets/styles/style.css
@@ -440,6 +440,91 @@ video {
   display: none;
 }
 
+:root {
+  --bullet-toggle-size: 46px;
+  --toogle-width: 100px;
+  --toogle-height: 54px;
+  --light-mode-background: #f1c40f;
+  --dark-mode-background: #025BDF;
+  --dark-container-background: #3F3F3F;
+  --dark-container-text: #fff;
+}
+
+.dark-mode-toggle {
+  position: relative;
+  display: inline-block;
+  width: var(--toogle-width);
+  height: var(--toogle-height);
+}
+
+.dark-mode-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.dark-mode-toggle label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #EEE;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.dark .dark-mode-toggle label {
+  background-color: #fff;
+}
+
+.dark-mode-toggle label .bullet {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 5%;
+  transform: translate(0, -50%);
+  width: var(--bullet-toggle-size);
+  aspect-ratio: 1;
+  background-color: var(--light-mode-background);
+  border-radius: 50%;
+  transition: background-color 0.2s ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dark-mode-toggle input:checked + label .bullet {
+  background-color: var(--dark-mode-background);
+  left: 95%;
+  transform: translate(-100%, -50%);
+}
+
+.sun,
+  .moon {
+  position: relative;
+  z-index: 100;
+  fill: #fff;
+}
+
+.moon {
+  display: none;
+}
+
+.dark-mode-toggle input:checked + label .moon {
+  display: block;
+}
+
+.dark-mode-toggle input:checked + label .sun {
+  display: none;
+}
+
+.dark .page-card {
+  background-color: var(--dark-container-background);
+  color: var(--dark-container-text);
+}
+
 *, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -720,6 +805,10 @@ video {
 
 .max-w-lg {
   max-width: 32rem;
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .appearance-none {

--- a/src/common/index.ejs
+++ b/src/common/index.ejs
@@ -14,6 +14,7 @@
         <%= renderCard('Analytics Tracking', '🔎', '/analytics','Testing the tracking cross-site') %>
         <%= renderCard('Embedded Content', '📽️', '/embedded-video','Sharing data across sites with embedded content') %>
         <%= renderCard('E-Commerce', '🛒', '/ecommerce','Storage a shopping cart across sites via iframe') %>
+        <%= renderCard('User preferences', '🎨', '/user-preferences','Using cookies to set user preferences cross-domain') %>
         <%= renderCard('Single Sign-On', '🔐', '/single-sign-on','Using third-party providers to creating a login session') %>
         <%= renderCard('Payment Gateway', '💳', '/payment-gateway','Payment flow simulation with credit card') %>
         <%= renderCard('CHIPS', '🍪', '/chips','Using CHIPS to solve tracking issues across third-party applications') %>

--- a/src/common/internal-page/header.ejs
+++ b/src/common/internal-page/header.ejs
@@ -4,4 +4,4 @@
                 <h1 class="text-3xl font-bold my-8 text-center text-slate-800"><%= title %></h1>
             </header>
         <% } %>
-        <div class="border p-8 bg-white drop-shadow-[8px_8px_0_rgba(32,33,37,.1)] rounded-lg text-center w-[60rem] mx-auto max-w-full">
+        <div class="page-card border p-8 bg-white drop-shadow-[8px_8px_0_rgba(32,33,37,.1)] rounded-lg text-center w-[60rem] mx-auto max-w-full transition duration-300">

--- a/src/scenarios/user-preferences/index.ejs
+++ b/src/scenarios/user-preferences/index.ejs
@@ -1,0 +1,20 @@
+<%- include(commonPath + '/header.ejs') %>
+    <div id="theme-container">
+    <%- include(commonPath + '/internal-page/header.ejs') %>
+        <p class="text-lg mb-4 text-center">Here you can set you prefered theme.</p>
+
+        <div class="dark-mode-toggle">
+            <input type="checkbox" id="dark-mode-switch" onclick="toggleTheme()" />
+            <label for="dark-mode-switch">
+                <span class="bullet">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="sun" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 0 0 0-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 0 0 0-1.41.996.996 0 0 0-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 0 0 0-1.41.996.996 0 0 0-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="moon" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26 5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg>
+                </span>
+            </label>
+        </div>
+    <%- include(commonPath + '/internal-page/footer.ejs') %>
+    </div>
+
+<script src="<%= protocol %>://<%= domainC %><% if (isPortPresent) { %>:<%= port %><% } %>/user-preferences/user-preference.js"></script>
+
+<%- include(commonPath + '/footer.ejs') %>

--- a/src/scenarios/user-preferences/routes.js
+++ b/src/scenarios/user-preferences/routes.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const path = require('path');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+    res.render(path.join(__dirname,'index'), {
+        title: 'User Preferences'
+    });
+});
+
+router.get( '/get-user-preference', ( req, res ) => {
+    const currentTheme = req.cookies.theme || 'light';
+    res.json( { theme: currentTheme });
+});
+
+router.post( '/set-user-preference', ( req, res ) => {
+    const { theme } = req.body;
+    
+    if (!theme) {
+        res.status(400).send({ message: 'Invalid request' });
+        
+    }
+    
+    res.cookie('theme', theme, {
+        domain: res.locals.domainC,
+        maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+        httpOnly: true,
+        sameSite: "none",
+        secure: true
+    });
+    res.status(200).send({ message: 'Success', theme : theme});
+});
+
+// Serve the user-preference.js file to the site
+router.get('/user-preference.js', (req, res) => {
+    res.set('Content-Type', 'application/javascript');
+    res.render(path.join(__dirname,'user-preference'));
+});
+
+module.exports = router;

--- a/src/scenarios/user-preferences/user-preference.ejs
+++ b/src/scenarios/user-preferences/user-preference.ejs
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const baseURL = '<%= protocol %>://<%= domainC %><% if (isPortPresent) { %>:<%= port %><% } %>/user-preferences';
+    const pageContainer = document.getElementById('theme-container');
+    const themeSwitcher = document.getElementById('dark-mode-switch');
+    
+    function updateUserPreference() {
+        fetch(`${baseURL}/get-user-preference`)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(data => {
+                const theme = data.theme;
+                console.log(data.theme)
+                pageContainer.className = theme;
+                themeSwitcher.checked = theme === 'dark';
+            })
+            .catch(error => {
+                console.error('There has been a problem with your fetch operation:', error);
+            }); 
+    }
+
+    function toggleTheme() {
+        fetch( `${baseURL}/set-user-preference`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ theme: themeSwitcher?.checked ? 'dark' : 'light' })
+        })
+        .then(response => response.json())
+        .then(data => {
+            pageContainer.className = data.theme;
+        });
+    }
+    window.toggleTheme = toggleTheme;
+    updateUserPreference();
+});

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -1,3 +1,92 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+
+  :root {
+      --bullet-toggle-size: 46px;
+      --toogle-width: 100px;
+      --toogle-height: 54px;
+      --light-mode-background: #f1c40f;
+      --dark-mode-background: #025BDF;
+      --dark-container-background: #3F3F3F;
+      --dark-container-text: #fff;
+  }
+
+  .dark-mode-toggle {
+      position: relative;
+      display: inline-block;
+      width: var(--toogle-width);
+      height: var(--toogle-height);
+  }
+
+  .dark-mode-toggle input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+  }
+
+  .dark-mode-toggle label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #EEE; 
+    border-radius: 30px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .dark .dark-mode-toggle label {
+    background-color: #fff; 
+  }
+
+  .dark-mode-toggle label .bullet {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 5%;
+    transform: translate(0, -50%);
+    width: var(--bullet-toggle-size);
+    aspect-ratio: 1;
+    background-color: var(--light-mode-background); 
+    border-radius: 50%;
+    transition: background-color 0.2s ease-in-out;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dark-mode-toggle input:checked + label .bullet {
+    background-color: var(--dark-mode-background);
+    left: 95%;
+    transform: translate(-100%, -50%);
+  }
+
+  .sun,
+  .moon {
+      position: relative;
+      z-index: 100;
+      fill: #fff;
+  }
+
+  .moon {
+    display: none;
+  }
+
+  .dark-mode-toggle input:checked + label .moon {
+    display: block;
+  }
+
+  .dark-mode-toggle input:checked + label .sun {
+    display: none;
+  }
+
+  .dark .page-card {
+    background-color: var(--dark-container-background);
+    color: var(--dark-container-text);
+  }
+
+}


### PR DESCRIPTION
Hi @gagan0123, This pull request is on draft; I have a few items that I want to check:

 - I will include status messages on the preference page, same as the analytics page
 - I'm loading the preferences on `domain C`; when the page is fetching, I have a tiny blink between dark and light mode. Can I add a loader for it?
 - Some JavaScript files are using `(function(){}())`, and some are using `DOMContentLoaded`. Should we define a standard to load and execute JavaScript? 


**Homepage**
![home page](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/e654457f-22df-4344-81e9-5d4fb4d5eeb6)

**Light Mode**
![light mode](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/4239e8e0-0db9-40fd-891c-7ea34e658a15)


**Dark Mode**
![dark mode](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/ce1281d2-79db-4569-a019-056dab6806ce)





