### PR TITLE
Remove sign out button after user logout

### DIFF
--- a/public/assets/styles/style.css
+++ b/public/assets/styles/style.css
@@ -873,6 +873,11 @@ video {
   padding-right: 1rem;
 }
 
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
 .py-2 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;

--- a/src/scenarios/gsi/index.ejs
+++ b/src/scenarios/gsi/index.ejs
@@ -24,6 +24,7 @@
         const auth2 = gapi.auth2.getAuthInstance();
         auth2.signOut().then(function () {
         statusMessage.textContent = '';
+        signoutBtn.classList.add('hidden');
         });
     }
 </script>

--- a/src/scenarios/gsi/index.ejs
+++ b/src/scenarios/gsi/index.ejs
@@ -1,14 +1,13 @@
 <%- include(commonPath + '/header.ejs') %>
 
-<div class="container mx-auto py-8">
-    <h1 class="text-3xl font-bold mb-4 text-center">Legacy Google Sign-in</h1>
+<%- include(commonPath + '/internal-page/header.ejs') %>
     <p class="text-lg font-bold mb-4 text-center">Please login to test this demo.</p>
     <div class="flex justify-center">
         <div class="g-signin2" data-onsuccess="onSignIn"></div>
-        <button id="signout-btn" class="hidden ml-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onclick="signOut()">Sign Out</button>
+        <button id="signout-btn" class="hidden ml-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-4 rounded" onclick="signOut()">Sign Out</button>
     </div>
     <div id="status" class="text-center text-lg mt-4"></div>
-</div>
+<%- include(commonPath + '/internal-page/footer.ejs') %>
 
 <script>
     const statusMessage = document.getElementById('status');

--- a/src/scenarios/gsi/routes.js
+++ b/src/scenarios/gsi/routes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 router.get('/', (req, res) => {
     // Send the default page
     res.render(path.join(__dirname,'index'), {
-        title: 'Legacy GSI'
+        title: 'Legacy Google Sign-in'
     });
 });
 


### PR DESCRIPTION
## Description

This pull request contains a fix suggested by @gagan0123 to remove the signout button after the user logs out. And adds the new internal page design:


**New internal page:**
![Screenshot 2024-02-02 at 12 04 49](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/bd8e3b2e-63a1-4728-a0b7-ba5ea4b46cbc)

**Old internal page:**
![Screenshot 2024-02-02 at 12 02 09](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/14fe6acd-b98e-495b-baa0-bf4e117d4356)


**Logout user:**
![Screenshot 2024-02-02 at 12 05 00](https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/2abdeec3-b2de-4920-9f77-87b19aae6511)
