### PR TITLE
Fix for personalization demo

### DIFF
--- a/src/scenarios/personalization/personalization.ejs
+++ b/src/scenarios/personalization/personalization.ejs
@@ -4,7 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const themeSwitcher = document.getElementById('dark-mode-switch');
     
     function updateUserPreference() {
-        fetch(`${baseURL}/get-personalization`)
+        fetch(`${baseURL}/get-personalization`, {
+            method: 'GET',
+            credentials: 'include'
+        })
             .then(response => {
                 if (!response.ok) {
                     throw new Error('Network response was not ok');


### PR DESCRIPTION
## Description 

This pull request includes the parameters `method` and `credentials` to allow the fetching of cookies from `domain C`.

## Screencast


domain C
<img width="332" alt="Screenshot 2024-02-12 at 15 07 38" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/93291971-52e2-4444-b468-c01f133991a3">

domain A
<img width="331" alt="Screenshot 2024-02-12 at 15 07 30" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/2e6df511-8fab-40c8-86e3-75a07ab3bd47">
