### PR TITLE
Streamline CHIPS demo

### DIFF
--- a/src/demos/chips/analytics-first-party.ejs
+++ b/src/demos/chips/analytics-first-party.ejs
@@ -1,13 +1,12 @@
 <%- include(commonPath + '/header.ejs') %>
 
 	<%- include(commonPath + '/internal-page/header.ejs') %>
-		<p class="text-center">Track user interactions using the analytics code provided below:</p>
 		<div class="flex justify-center space-x-4 mt-4">
 			<button onclick="trackInteraction('buttonClicked')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">
 				Track me!
 			</button>
 			<button onclick="trackInteraction('buttonClickedCHIPS')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">
-				CHIPS Track me!
+				Track me! (CHIPS)
 			</button>
 		</div>
 		<div id="status" class="text-center mt-4"></div>

--- a/src/demos/chips/analytics-third-party.ejs
+++ b/src/demos/chips/analytics-third-party.ejs
@@ -1,14 +1,12 @@
 <%- include(commonPath + '/header.ejs') %>
 
 	<%- include(commonPath + '/internal-page/header.ejs') %>
-		<p class="text-center">Track user interactions using the analytics code provided below:</p>
-
 		<div class="flex justify-center space-x-4 mt-4">
 			<button onclick="trackInteraction('buttonClicked')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">
 				Track me!
 			</button>
 			<button onclick="trackInteraction('buttonClickedCHIPS')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">
-				CHIPS Track me!
+				Track me! (CHIPS)
 			</button>
 		</div>
 		<div id="status" class="text-center mt-4"></div>

--- a/src/demos/chips/analytics.ejs
+++ b/src/demos/chips/analytics.ejs
@@ -22,7 +22,7 @@
 			} ).then( function ( data ) {
 				var statusDiv = document.getElementById( 'status' );
 				if ( statusDiv ) {
-					statusDiv.textContent = 'Interaction tracked for ID : ' + data;
+					statusDiv.textContent = 'Interaction tracked!';
 					statusDiv.style.color = 'green';
 				}
 			} ).catch( function ( error ) {

--- a/src/demos/chips/routes.js
+++ b/src/demos/chips/routes.js
@@ -5,19 +5,15 @@ const uuid = require( 'uuid' );
 
 router.get('/', (req, res) => {
 	// Send the default page
-	res.render(path.join(__dirname,'index'), {
+	res.render(path.join(__dirname,'analytics-third-party'), {
 		title: 'CHIPS'
 	});
 });
-router.get('/analytics-first-party', (req, res) => {
-	res.render(path.join(__dirname,'analytics-first-party'), {
-		title: 'First Party Cookie Experiments'
-	});
-});
+
 router.get('/analytics-third-party', (req, res) => {
 	// Send the default page
 	res.render(path.join(__dirname,'analytics-third-party'), {
-		title: 'Third Party Cookie Experiments'
+		title: 'CHIPS'
 	});
 });
 // Serve the analytics.js file to the site
@@ -39,16 +35,16 @@ router.get( '/analytics.js', ( req, res ) => {
 
 	}
 
-	let analyticsIdCHIPS = req.cookies['__Host-analyticsId-chips'];
+	let analyticsIdCHIPS = req.cookies['analyticsId-chips'];
 
 	if ( !analyticsIdCHIPS ) {
 		analyticsIdCHIPS = uuid.v4();
 		let expire = 30 * 24 * 60 * 60 * 1000;
-		res.append(
+		/*res.append(
 			'Set-Cookie', '__Host-analyticsId-chips=' + analyticsIdCHIPS + '; Max-Age=' + expire + '; HttpOnly; Secure; Path=/; SameSite=None; Partitioned;'
-		);
+		);*/
 		res.append(
-			'Set-Cookie', 'analyticsId-chips-test=' + analyticsIdCHIPS + ';Domain='+res.locals.domainC+'; Max-Age=' + expire + '; HttpOnly; Secure; Path=/; SameSite=None; Partitioned;'
+			'Set-Cookie', 'analyticsId-chips=' + analyticsIdCHIPS + ';Domain='+res.locals.domainC+'; Max-Age=' + expire + '; HttpOnly; Secure; Path=/; SameSite=None; Partitioned;'
 		);
 	}
 
@@ -73,7 +69,7 @@ router.post( '/track', ( req, res ) => {
 
 router.post( '/trackCHIPS', ( req, res ) => {
 	const {interaction} = req.body;
-	const analyticsIdCHIPS = req.cookies['__Host-analyticsId-chips'];
+	const analyticsIdCHIPS = req.cookies['analyticsId-chips'];
 
 	if ( interaction && analyticsIdCHIPS ) {
 

--- a/src/scenarios/analytics/index.ejs
+++ b/src/scenarios/analytics/index.ejs
@@ -1,7 +1,6 @@
 <%- include(commonPath + '/header.ejs') %>
 
     <%- include(commonPath + '/internal-page/header.ejs') %>
-        <p class="text-lg mb-4 text-center">Here is a button that tracks clicks using a third-party analytics service; check if it works.</p>
 
         <div class="flex justify-center space-x-4 my-10">
             <button onclick="trackInteraction('buttonClicked')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300">


### PR DESCRIPTION
* Remove First-Party Analytics page — was just a test page and not needed anymore
* Change the name of the partitioned cookie
* Removed unused test cookie
* Renamed CHIPS title and description