### PR TITLE
Adding Spotify demo

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,6 +74,7 @@ const scenarios = [
 	'social-media',
 	'social-media-comments',
 	'disqus-comments',
+	'spotify-embed',
 ];
 scenarios.forEach(scenario => {
 	const scenarioRoutes = require(`./src/scenarios/${scenario}/routes`);

--- a/src/common/index.ejs
+++ b/src/common/index.ejs
@@ -21,8 +21,10 @@
         <%= renderCard('Facebook Like', '👍', '/social-media') %>
         <%= renderCard('Facebook Comments', '💬', '/social-media-comments') %>
         <%= renderCard('Disqus Comments', '✉️', '/disqus-comments') %>
+        <%= renderCard('Spotify embed', '🔊', '/spotify-embed') %>
         <%= renderCard('CHIPS', '🍪', '/chips') %>
         <%= renderCard('Storage Access API', '🗃️', '/storage-access-api') %>
+
     </div>
 </div>
 

--- a/src/scenarios/spotify-embed/index.ejs
+++ b/src/scenarios/spotify-embed/index.ejs
@@ -1,0 +1,6 @@
+<%- include(commonPath + '/header.ejs') %>
+
+    <%- include(commonPath + '/internal-page/header.ejs', {containerType: 'sm'}) %>
+        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/7makk4oTQel546B0PZlDM5?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+    <%- include(commonPath + '/internal-page/footer.ejs') %>
+<%- include(commonPath + '/footer.ejs') %>

--- a/src/scenarios/spotify-embed/routes.js
+++ b/src/scenarios/spotify-embed/routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const path = require('path');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+    // Send the default page
+    const currentDomain = req.get('host');
+    res.render(path.join(__dirname,'index'), {
+        title: 'Spotify Player'
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Description 

During the London Workshop, I interacted with the Spotify team. The player currently runs under an exception but has a known breakage related to keeping the Spotify session over the embedded player.

It is also an opportunity to show the exception feature.

**Index**

<img width="1042" alt="Screenshot 2024-04-16 at 10 30 46" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/e0ac11f4-3268-4fc6-94ac-5a4afeb822f7">


**Internal page**
<img width="1043" alt="Screenshot 2024-04-16 at 10 22 07" src="https://github.com/rtCamp/privacy-sandbox-demos/assets/330792/cf5bdf47-061c-4409-8908-b9280f5670ea">
