### PR TITLE
Add media container sizes and div Id to single seller auction.

### DIFF
--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -251,6 +251,8 @@ app.get('/auction-config.json', async (req, res) => {
     // only for single party
     sellerSignals: {
       seller_signals: 'seller_signals',
+      divId: 'image-ad--iframe-single-seller',
+      size: [300, 250]
     },
 
     // only for single party

--- a/services/ssp/src/views/index.html.ejs
+++ b/services/ssp/src/views/index.html.ejs
@@ -25,7 +25,7 @@
     <p>SSP provides 3rd party tag which running auction via Protected Audience API and decide which
       Ads to display</p>
     <p>Ads will embed inside &lt;fencedframe&gt; like below.</p>
-    <ins class="ads">
+    <ins id="image-ad--iframe-single-seller" class="ads">
       <script class="ssp_tag"
               src="<%= new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}/ad-tag.js`) %>"></script>
     </ins>


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](CONTRIBUTING.md).**

# Description

Similar to the changes in the demo for multiseller auction, this PR aims to add media Container and divId to the sellerSignals.

## Related Issue

- Fixes #xxx

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [x] SSP
- [ ] ALL

Other:
