### PR TITLE
Add support for 'fenced-frame' loading mode for video ads

### DIFF
--- a/services/dsp/src/index.ts
+++ b/services/dsp/src/index.ts
@@ -83,6 +83,9 @@ app.use(
       if (url.pathname.endsWith('bidding_signal.json')) {
         return res.set('X-Allow-FLEDGE', 'true');
       }
+      if (url.pathname.endsWith('video-ad-creative.html')) {
+        return res.set('Supports-Loading-Mode', 'fenced-frame');
+      }
     },
   }),
 );


### PR DESCRIPTION
**Description:** This update in the DSP service includes setting the 'Supports-Loading-Mode' header to 'fenced-frame' for requests to 'video-ad-creative.html', ensuring compatibility with secure loading modes for video ad creatives. No changes were made to existing behavior for other endpoints. 
